### PR TITLE
Added support for sizeToFit

### DIFF
--- a/StyledPageControlDemo/PageControlDemo/StyledPageControl.m
+++ b/StyledPageControlDemo/PageControlDemo/StyledPageControl.m
@@ -407,4 +407,9 @@
     return aSelectedThumbImage;
 }
 
+- (CGSize)sizeThatFits:(CGSize)size {
+    CGFloat controlSize = _diameter + _strokeWidth;
+    return CGSizeMake(_numberOfPages * controlSize + (_numberOfPages - 1) * _gapWidth, controlSize);
+}
+
 @end


### PR DESCRIPTION
Currently it is not possible to get the bounds of the page control using `[pageControl sizeToFit];`. This PR adds this capability.